### PR TITLE
Add nat skin solr8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,17 @@ RUN cd /var/www/foswiki && \
     tools/configure -save -set {DefaultUrlHost}='http://localhost' && \
     tools/configure -save -set {SafeEnvPath}='/bin:/usr/bin' && \
     tools/extension_installer ActionTrackerPlugin -r -enable install && \
+    tools/extension_installer AutoTemplatePlugin -r -enable install && \
+    tools/extension_installer BreadCrumbsPlugin -r -enable install && \
     tools/extension_installer NatSkin -r -enable install && \
     tools/extension_installer JQPhotoSwipeContrib -r -enable install && \
     tools/extension_installer ClassificationPlugin -r -enable install && \
+    tools/extension_installer DBCachePlugin -r -enable install && \
     tools/extension_installer DiffPlugin -r -enable install && \
     tools/extension_installer DocumentViewerPlugin -r -enable install && \
+    tools/extension_installer EditChapterPlugin -r -enable install && \
+    tools/extension_installer FlexFormPlugin -r -enable install && \
+    tools/extension_installer FlexWebListPlugin -r -enable install && \
     tools/extension_installer FilterPlugin -r -enable install && \
     tools/extension_installer GluePlugin -r -enable install && \
     tools/extension_installer GraphvizPlugin -r -enable install && \
@@ -95,6 +101,7 @@ RUN cd /var/www/foswiki && \
     tools/extension_installer MimeIconPlugin -r -enable install && \
     tools/extension_installer MoreFormfieldsPlugin -r -enable install && \
     tools/extension_installer MultiLingualPlugin -r -enable install && \
+    tools/extension_installer PubLinkFixupPlugin -r -enable install && \
     tools/extension_installer NewUserPlugin -r -enable install && \
     tools/extension_installer RedDotPlugin -r -enable install && \
     tools/extension_installer RenderPlugin -r -enable install && \
@@ -102,6 +109,7 @@ RUN cd /var/www/foswiki && \
     tools/extension_installer TagCloudPlugin -r -enable install && \
     tools/extension_installer TopicInteractionPlugin -r -enable install && \
     tools/extension_installer TopicTitlePlugin -r -enable install && \
+    tools/extension_installer WebLinkPlugin -r -enable install && \
     tools/extension_installer WorkflowPlugin -r -enable install && \
     rm -fr /var/www/foswiki/working/configure/download/* && \
     rm -fr /var/www/foswiki/working/configure/backup/*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,16 +23,29 @@ services:
       - solr_configsets:/opt/solr/server/solr/configsets:z
       - solr_foswiki:/opt/solr/server/solr/solr_foswiki:z
       - foswiki_www:/var/www/foswiki:z
-    command: sh -c "cd /var/www/foswiki; chown -R 8983:8983 solr; sed -i '/SolrPlugin..Url/s/localhost/solr/' lib/LocalSite.cfg; cd /opt/solr/server/solr/configsets ; [ -L foswiki_configs ] && rm foswiki_configs ; ln -s /var/www/foswiki/solr/configsets/foswiki_configs/ . ; cd /opt/solr/server/solr/solr_foswiki ; [ -L core.properties ] && rm core.properties ; ln -s /var/www/foswiki/solr/cores/foswiki/core.properties ; chown -R 8983:8983 /opt/solr/server/solr ."
+    # Setup Solr 
+    # Set default skin to Nat, if no skin specified otherwise
+    command: sh -c "
+      chown -R 8983:8983 /opt/solr/server/solr ;
+      chown -R 8983:8983 /var/www/foswiki/solr ;
+
+      cd /opt/solr/server/solr/configsets ;
+      [ -L foswiki_configs ] && rm foswiki_configs ;
+      ln -s /var/www/foswiki/solr/configsets/foswiki_configs/ . ;
+
+      cd /opt/solr/server/solr/solr_foswiki ;
+      [ -L core.properties ] && rm core.properties ;
+      ln -s /var/www/foswiki/solr/cores/foswiki/core.properties ;
+
+      sed -i '/SolrPlugin..Url/s/localhost/solr/' /var/www/foswiki/lib/LocalSite.cfg ;
+
+      cd /var/www/foswiki/; ! [ `grep -l \"SKIN\" data/Main/SitePreferences.txt` ] && sed -i '/---++ Appearance/a\ \ \ * Set SKIN = nat' data/Main/SitePreferences.txt ; "
 
   solr:
     image: solr:5
     container_name: solr
     depends_on:
       - setup
-    # only usefull to have access to solr console, will be delete in production
-    ports:
-      - 8983:8983
     volumes:
       - solr_logs:/opt/solr/server/logs:z
       - solr_configsets:/opt/solr/server/solr/configsets:z


### PR DESCRIPTION
Hello Tim,

Here is a proposal of modifications : 
Dockerfile : add EditChapterPlugin, very handy IMHO and well integrated into NatSkin
docker-compose.yml : change default Skin to NatSkin

I've also tried to set an admin password within the docker-compose file, no luck so far. I've had lots of trouble with escaping quotes and stuff within the sed command. Still working on it, except if you find that this would not be a good thing to the Admin pass this way.

Also, about 8765 port instead of 80 : I've done that since most of the time the 80 port is already used on the machine I will be running Foswiki on, also I may use another web server to proxy to the container. Are you ok with have this non 80 port ?

Talking about web server : I am not sure about integrating nginx withi the docker image. Shouldn't it be done within the docker-compose ? A better modularity / independence as an advantage, but as a drawback a non-functional image on its own. 

Cheers,
Michel