### PR TITLE
Allow to run multiple instances of the Foswiki service with compose :

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,20 +3,16 @@ version: '3'
 services:
   foswiki:
     image: timlegge/docker-foswiki
-    container_name: foswiki
     ports:
-      - 8765:80
+      - "${FOSWIKI_PORT}:80"
     volumes:
       - solr_logs:/opt/solr/server/logs:z
       - solr_configsets:/opt/solr/server/solr/configsets:z
       - solr_foswiki:/opt/solr/server/solr/solr_foswiki:z
       - foswiki_www:/var/www/foswiki:z
-    networks:
-      - foswiki-network
 
   setup:
     image: alpine:latest
-    container_name: setup
     depends_on:
       - foswiki
     volumes:
@@ -42,7 +38,6 @@ services:
 
   solr:
     image: solr:5
-    container_name: solr
     depends_on:
       - setup
     volumes:
@@ -53,8 +48,6 @@ services:
     environment:
       - GC_LOG_OPTS=''
       - SOLR_LOG_LEVEL='WARN'
-    networks:
-      - foswiki-network
 
 volumes:
   foswiki_www:
@@ -62,5 +55,3 @@ volumes:
   solr_configsets:
   solr_foswiki:
 
-networks:
-  foswiki-network:


### PR DESCRIPTION
- removed the fixed containers names
- removed the fixed network name
- added $FOSWIKI_PORT for the local port to use
