### PR TITLE
Allows multiple instances of Foswiki

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,20 +3,16 @@ version: '3'
 services:
   foswiki:
     image: timlegge/docker-foswiki
-    container_name: foswiki
     ports:
-      - 8765:80
+      - "${FOSWIKI_PORT}:80"
     volumes:
       - solr_logs:/opt/solr/server/logs:z
       - solr_configsets:/opt/solr/server/solr/configsets:z
       - solr_foswiki:/opt/solr/server/solr/solr_foswiki:z
       - foswiki_www:/var/www/foswiki:z
-    networks:
-      - foswiki-network
 
   setup:
     image: alpine:latest
-    container_name: setup
     depends_on:
       - foswiki
     volumes:
@@ -42,7 +38,6 @@ services:
 
   solr:
     image: solr:5
-    container_name: solr
     depends_on:
       - setup
     volumes:
@@ -53,8 +48,6 @@ services:
     environment:
       - GC_LOG_OPTS=''
       - SOLR_LOG_LEVEL='WARN'
-    networks:
-      - foswiki-network
 
 volumes:
   foswiki_www:
@@ -62,5 +55,3 @@ volumes:
   solr_configsets:
   solr_foswiki:
 
-networks:
-  foswiki-network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   foswiki:
     image: timlegge/docker-foswiki
     ports:
-      - "${FOSWIKI_PORT}:80"
+      - "${FOSWIKI_PORT:-8765}:80"
     volumes:
       - solr_logs:/opt/solr/server/logs:z
       - solr_configsets:/opt/solr/server/solr/configsets:z


### PR DESCRIPTION
Hello Tim,

These modifications allows to run multiple instances of the Foswiki composed service.

- `docker-compose up` is still the default to start one instance, on port 8765 
- `FOSWIKI_PORT=8888 docker-compose up` changes the default port to 8888

And for multiple instances : 
- `FOSWIKI_PORT=8761 docker-compose -p fw1 up` for first instance named `fw1` on port 8761
- `FOSWIKI_PORT=8762 docker-compose -p fw2 up` for second instance named `fw2` on port 8762

The containers, volumes and networks gets their names prefixed by the instance name, so that the instances are totally isolated.

Next step for me - and probably last one to date -  will be to be able to override the default location of the volumes. From what I understand, this can be done using a `docker-compose.override.yml` file.  Would you be interested to have a feedback on this when I'll get it ?

Have a good one,
Michel

