### PR TITLE
Change rewrite /Main/WebHome to /bin/view

### DIFF
--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -30,7 +30,7 @@ server {
 
     location = / {
         root $foswiki_root;
-        rewrite .* /Main/WebHome;
+        rewrite .* /bin/view;
     }
 
     # redirect short urls to view


### PR DESCRIPTION
Hi Tim,
I have been using docker-foswiki and found a minor inconvenience. The nginx.default.conf rewrites 
/ to /Main/WebHome

This works, but it defeats HomePage plugin. It looks for the absence of a web/topic pair.

Changing the rewrite from /Main/WebHome to /bin/view gives HopePage plugin what it wants and I don't believe there are any side effects.

I leave it for your consideration.